### PR TITLE
Add mode selection screen with persistent navigation

### DIFF
--- a/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
@@ -7,40 +7,98 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.joshiminh.cbzconverter.backend.ContextHelper
 import com.joshiminh.cbzconverter.backend.MainViewModel
-import com.joshiminh.cbzconverter.ui.normal.CbzConverterPage
-import com.joshiminh.cbzconverter.ui.normal.ConfigurationPage
 import com.joshiminh.cbzconverter.theme.CbzConverterTheme
+import com.joshiminh.cbzconverter.ui.mihon.MihonCbzConverterPage
+import com.joshiminh.cbzconverter.ui.normal.CbzConverterPage
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        val prefs = getPreferences(MODE_PRIVATE)
         setContent {
             CbzConverterTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    MainScreen(
-                        viewModel = MainViewModel(ContextHelper(this)),
-                        activity = this,
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                var selectedMode by rememberSaveable {
+                    mutableStateOf(prefs.getString("selected_mode", null))
                 }
+                when (selectedMode) {
+                    "normal" ->
+                        NormalModeScreen(
+                            activity = this,
+                            onBack = {
+                                selectedMode = null
+                                prefs.edit().remove("selected_mode").apply()
+                            },
+                        )
+
+                    "mihon" ->
+                        MihonModeScreen(
+                            onBack = {
+                                selectedMode = null
+                                prefs.edit().remove("selected_mode").apply()
+                            },
+                        )
+
+                    else ->
+                        ModeSelectionScreen(
+                            onNormal = {
+                                selectedMode = "normal"
+                                prefs.edit().putString("selected_mode", "normal").apply()
+                            },
+                            onMihon = {
+                                selectedMode = "mihon"
+                                prefs.edit().putString("selected_mode", "mihon").apply()
+                            },
+                        )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ModeSelectionScreen(onNormal: () -> Unit, onMihon: () -> Unit) {
+    Scaffold { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(onClick = onMihon) {
+                Text("Mihon Mode")
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onNormal) {
+                Text("Normal Mode")
             }
         }
     }
@@ -48,7 +106,8 @@ class MainActivity : ComponentActivity() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MainScreen(viewModel: MainViewModel, activity: ComponentActivity, modifier: Modifier = Modifier) {
+fun NormalModeScreen(activity: ComponentActivity, onBack: () -> Unit) {
+    val viewModel = remember { MainViewModel(ContextHelper(activity)) }
     val isCurrentlyConverting by viewModel.isCurrentlyConverting.collectAsState()
     val currentTaskStatus by viewModel.currentTaskStatus.collectAsState()
     val currentSubTaskStatus by viewModel.currentSubTaskStatus.collectAsState()
@@ -61,38 +120,28 @@ fun MainScreen(viewModel: MainViewModel, activity: ComponentActivity, modifier: 
     val overrideFileName by viewModel.overrideFileName.collectAsState()
     val overrideOutputDirectoryUri by viewModel.overrideOutputDirectoryUri.collectAsState()
 
-    val scope = rememberCoroutineScope()
-    val scaffoldState = rememberBottomSheetScaffoldState()
-
-    val filePickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris: List<Uri> ->
-        uris.let {
-            viewModel.updateUpdateSelectedFileUriFromUserInput(it)
+    val filePickerLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris: List<Uri> ->
+            viewModel.updateUpdateSelectedFileUriFromUserInput(uris)
         }
-    }
-
-    val directoryPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? ->
-        uri?.let {
-            viewModel.updateOverrideOutputPathFromUserInput(it)
+    val directoryPickerLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? ->
+            uri?.let { viewModel.updateOverrideOutputPathFromUserInput(it) }
         }
-    }
 
-    BottomSheetScaffold(
-        sheetContent = {
-            ConfigurationPage(
-                maxNumberOfPages,
-                batchSize,
-                viewModel,
-                isCurrentlyConverting,
-                overrideSortOrderToUseOffset,
-                overrideMergeFiles,
-                overrideFileName,
-                selectedFilesUri,
-                overrideOutputDirectoryUri,
-                activity,
-                directoryPickerLauncher
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("CBZ Converter") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
             )
-        },
-        content = {
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
             CbzConverterPage(
                 selectedFileName,
                 viewModel,
@@ -101,24 +150,42 @@ fun MainScreen(viewModel: MainViewModel, activity: ComponentActivity, modifier: 
                 isCurrentlyConverting,
                 selectedFilesUri,
                 currentTaskStatus,
-                currentSubTaskStatus
+                currentSubTaskStatus,
+                maxNumberOfPages,
+                batchSize,
+                overrideSortOrderToUseOffset,
+                overrideMergeFiles,
+                overrideFileName,
+                overrideOutputDirectoryUri,
+                directoryPickerLauncher
             )
-        },
-        scaffoldState = scaffoldState,
-        topBar = {
-            TopAppBar (title = { Text("CBZ Converter") })
-        },
-        sheetPeekHeight = 140.dp
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun MainScreenPreview() {
-    CbzConverterTheme {
-        MainScreen(
-            viewModel = MainViewModel(contextHelper = ContextHelper(ComponentActivity())),
-            activity = ComponentActivity()
-        )
+        }
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MihonModeScreen(onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Mihon Mode") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            MihonCbzConverterPage()
+        }
+    }
+}
+

--- a/app/src/main/java/com/joshiminh/cbzconverter/ui/mihon/Configurations.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/ui/mihon/Configurations.kt
@@ -1,4 +1,4 @@
 package com.joshiminh.cbzconverter.ui.mihon
 
-class Configurations {
-}
+class Configurations
+

--- a/app/src/main/java/com/joshiminh/cbzconverter/ui/mihon/MihonCbzConverterPage.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/ui/mihon/MihonCbzConverterPage.kt
@@ -1,4 +1,20 @@
 package com.joshiminh.cbzconverter.ui.mihon
 
-class MihonCbzConverterPage {
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun MihonCbzConverterPage() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = "Mihon Mode")
+    }
 }
+
+

--- a/app/src/main/java/com/joshiminh/cbzconverter/ui/normal/CbzConverterPage.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/ui/normal/CbzConverterPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -37,12 +38,20 @@ fun CbzConverterPage(
     isCurrentlyConverting: Boolean,
     selectedFilesUri: List<Uri>,
     currentTaskStatus: String,
-    currentSubTaskStatus: String
+    currentSubTaskStatus: String,
+    maxNumberOfPages: Int,
+    batchSize: Int,
+    overrideSortOrderToUseOffset: Boolean,
+    overrideMergeFiles: Boolean,
+    overrideFileName: String,
+    overrideOutputDirectoryUri: Uri?,
+    directoryPickerLauncher: ManagedActivityResultLauncher<Uri?, Uri?>,
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(modifier = Modifier.height(16.dp))
@@ -53,7 +62,25 @@ fun CbzConverterPage(
             activity,
             filePickerLauncher,
             isCurrentlyConverting,
-            selectedFilesUri
+            selectedFilesUri,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Divider()
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ConfigurationsSegment(
+            maxNumberOfPages,
+            batchSize,
+            viewModel,
+            isCurrentlyConverting,
+            overrideSortOrderToUseOffset,
+            overrideMergeFiles,
+            overrideFileName,
+            selectedFilesUri,
+            overrideOutputDirectoryUri,
+            activity,
+            directoryPickerLauncher,
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -68,16 +95,25 @@ fun CbzConverterPage(
 }
 
 @Composable
-private fun TasksStatusSegment(currentTaskStatus: String, currentSubTaskStatus: String) {
+private fun TasksStatusSegment(
+    currentTaskStatus: String,
+    currentSubTaskStatus: String,
+) {
     Column(
-        Modifier.height(250.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .height(250.dp),
         verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = "Current Task Status (Scrollable):", fontWeight = FontWeight.SemiBold)
+        Text(
+            text = "Current Task Status (Scrollable):",
+            fontWeight = FontWeight.SemiBold,
+        )
         LazyColumn(
             Modifier.height(100.dp),
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Center,
         ) {
             items(currentTaskStatus.lines()) { line ->
                 Text(text = line)
@@ -86,10 +122,13 @@ private fun TasksStatusSegment(currentTaskStatus: String, currentSubTaskStatus: 
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Text(text = "Current Sub-Task Status (Scrollable):", fontWeight = FontWeight.SemiBold)
+        Text(
+            text = "Current Sub-Task Status (Scrollable):",
+            fontWeight = FontWeight.SemiBold,
+        )
         LazyColumn(
             Modifier.height(130.dp),
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Center,
         ) {
             items(currentSubTaskStatus.lines()) { line ->
                 Text(text = line)
@@ -105,12 +144,15 @@ private fun FileConversionSegment(
     activity: ComponentActivity,
     filePickerLauncher: ManagedActivityResultLauncher<Array<String>, List<Uri>>,
     isCurrentlyConverting: Boolean,
-    selectedFilesUri: List<Uri>
+    selectedFilesUri: List<Uri>,
 ) {
     Column(
-        Modifier.height(230.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .height(230.dp),
         verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(text = "File to Convert (Scrollable):", fontWeight = FontWeight.SemiBold)
 
@@ -123,12 +165,11 @@ private fun FileConversionSegment(
         }
         Spacer(modifier = Modifier.height(16.dp))
 
-
         Button(
             onClick = {
                 viewModel.checkPermissionAndSelectFileAction(activity, filePickerLauncher)
             },
-            enabled = !isCurrentlyConverting
+            enabled = !isCurrentlyConverting,
         ) {
             Text(text = "Select CBZ File")
         }
@@ -136,11 +177,9 @@ private fun FileConversionSegment(
 
         Button(
             onClick = {
-                selectedFilesUri.let {
-                    viewModel.convertToPDF(it)
-                }
+                selectedFilesUri.let { viewModel.convertToPDF(it) }
             },
-            enabled = selectedFilesUri.isNotEmpty() && !isCurrentlyConverting
+            enabled = selectedFilesUri.isNotEmpty() && !isCurrentlyConverting,
         ) {
             Text(text = "Convert to PDF")
         }
@@ -162,7 +201,14 @@ fun CbzConverterPagePreview() {
             isCurrentlyConverting = false,
             selectedFilesUri = listOf(),
             currentTaskStatus = "",
-            currentSubTaskStatus = ""
+            currentSubTaskStatus = "",
+            maxNumberOfPages = 100,
+            batchSize = 300,
+            overrideSortOrderToUseOffset = false,
+            overrideMergeFiles = false,
+            overrideFileName = "test",
+            overrideOutputDirectoryUri = null,
+            directoryPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? -> }
         )
     }
 }

--- a/app/src/main/java/com/joshiminh/cbzconverter/ui/normal/Configurations.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/ui/normal/Configurations.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.KeyboardActions
@@ -37,7 +38,7 @@ import com.joshiminh.cbzconverter.backend.MainViewModel
 import com.joshiminh.cbzconverter.theme.CbzConverterTheme
 
 @Composable
-fun ConfigurationPage(
+fun ConfigurationsSegment(
     maxNumberOfPages: Int,
     batchSize: Int,
     viewModel: MainViewModel,
@@ -48,18 +49,19 @@ fun ConfigurationPage(
     selectedFilesUri: List<Uri>,
     overrideOutputDirectoryUri: Uri?,
     activity: ComponentActivity,
-    directoryPickerLauncher: ManagedActivityResultLauncher<Uri?, Uri?>
+    directoryPickerLauncher: ManagedActivityResultLauncher<Uri?, Uri?>,
 ) {
     val scrollState = rememberScrollState()
-    
+
     Column(
-        verticalArrangement = Arrangement.Center,
+        verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
+            .padding(16.dp)
     ) {
-        Text(text = "Configurations (Swipe Up to see all options)")
+        Text(text = "Configurations")
 
         Spacer(modifier = Modifier.height(16.dp))
         Divider()
@@ -71,7 +73,7 @@ fun ConfigurationPage(
             maxNumberOfPages,
             viewModel,
             focusManager,
-            isCurrentlyConverting
+            isCurrentlyConverting,
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -82,7 +84,7 @@ fun ConfigurationPage(
             batchSize,
             viewModel,
             focusManager,
-            isCurrentlyConverting
+            isCurrentlyConverting,
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -91,11 +93,13 @@ fun ConfigurationPage(
 
         SortOrderOverrideConfigSegment(overrideSortOrderToUseOffset, viewModel)
 
+        Spacer(modifier = Modifier.height(16.dp))
         Divider()
         Spacer(modifier = Modifier.height(16.dp))
 
         MergeFilesOverrideConfigSegment(overrideMergeFiles, viewModel)
 
+        Spacer(modifier = Modifier.height(16.dp))
         Divider()
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -104,7 +108,7 @@ fun ConfigurationPage(
             viewModel,
             focusManager,
             isCurrentlyConverting,
-            selectedFilesUri
+            selectedFilesUri,
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -116,11 +120,8 @@ fun ConfigurationPage(
             viewModel,
             activity,
             directoryPickerLauncher,
-            isCurrentlyConverting
+            isCurrentlyConverting,
         )
-        Spacer(modifier = Modifier.height(16.dp))
-        Divider()
-        Spacer(modifier = Modifier.height(48.dp))
     }
 }
 
@@ -130,25 +131,32 @@ private fun OutputDirectoryOverrideConfigSegment(
     viewModel: MainViewModel,
     activity: ComponentActivity,
     directoryPickerLauncher: ManagedActivityResultLauncher<Uri?, Uri?>,
-    isCurrentlyConverting: Boolean
+    isCurrentlyConverting: Boolean,
 ) {
-    Text(
-        if (overrideOutputDirectoryUri != null) {
-            "Current Output File Path: $overrideOutputDirectoryUri"
-        } else {
-            "No override output directory selected"
-        }
-    )
-    Spacer(modifier = Modifier.height(16.dp))
-
-    Button(
-        onClick = {
-            // todo look into why you cannot choose any directory, even though you have full access to storage
-            viewModel.checkPermissionAndSelectDirectoryAction(activity, directoryPickerLauncher)
-        },
-        enabled = !isCurrentlyConverting
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text(text = "Select & Override Output File Path")
+        Text(
+            if (overrideOutputDirectoryUri != null) {
+                "Current Output File Path: $overrideOutputDirectoryUri"
+            } else {
+                "No override output directory selected"
+            }
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = {
+                // todo look into why you cannot choose any directory, even though you have full access to storage
+                viewModel.checkPermissionAndSelectDirectoryAction(activity, directoryPickerLauncher)
+            },
+            enabled = !isCurrentlyConverting
+        ) {
+            Text(text = "Select & Override Output File Path")
+        }
     }
 }
 
@@ -158,68 +166,89 @@ private fun FileNameOverrideConfigSegment(
     viewModel: MainViewModel,
     focusManager: FocusManager,
     isCurrentlyConverting: Boolean,
-    selectedFilesUri: List<Uri>
+    selectedFilesUri: List<Uri>,
 ) {
-    Text(text = "Current File Name: $overrideFileName")
-    Spacer(modifier = Modifier.height(16.dp))
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Current File Name: $overrideFileName")
+        Spacer(modifier = Modifier.height(16.dp))
 
-    var tempFileNameOverride by remember { mutableStateOf(MainViewModel.EMPTY_STRING) }
+        var tempFileNameOverride by remember { mutableStateOf(MainViewModel.EMPTY_STRING) }
 
-    TextField(
-        value = tempFileNameOverride,
-        onValueChange = { tempFileNameOverride = it },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-        keyboardActions = KeyboardActions(onDone = {
-            viewModel.updateOverrideFileNameFromUserInput(tempFileNameOverride)
-            focusManager.clearFocus()
-        }),
-        label = {
-            if (!overrideFileName.contentEquals(tempFileNameOverride) && tempFileNameOverride.isNotBlank()) {
-                Text(
-                    text = "Value not saved, click Done (✓) on keyboard",
-                    color = Color.Red
-                )
-            } else {
-                Text("Override default file name (Exclude Extension)")
-            }
-        },
-        enabled = !isCurrentlyConverting && selectedFilesUri.isNotEmpty(),
-        singleLine = true
-    )
+        TextField(
+            value = tempFileNameOverride,
+            onValueChange = { tempFileNameOverride = it },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+            keyboardActions = KeyboardActions(onDone = {
+                viewModel.updateOverrideFileNameFromUserInput(tempFileNameOverride)
+                focusManager.clearFocus()
+            }),
+            label = {
+                if (!overrideFileName.contentEquals(tempFileNameOverride) && tempFileNameOverride.isNotBlank()) {
+                    Text(
+                        text = "Value not saved, click Done (✓) on keyboard",
+                        color = Color.Red
+                    )
+                } else {
+                    Text("Override default file name (Exclude Extension)")
+                }
+            },
+            enabled = !isCurrentlyConverting && selectedFilesUri.isNotEmpty(),
+            singleLine = true
+        )
+    }
 }
 
 @Composable
 private fun SortOrderOverrideConfigSegment(
     overrideSortOrderToUseOffset: Boolean,
-    viewModel: MainViewModel
+    viewModel: MainViewModel,
 ) {
-    Text(
-        text = "Default sort order uses file name (ASC)\n" +
-                "Override Sort Order to Use Offset: $overrideSortOrderToUseOffset"
-    )
-    Checkbox(
-        checked = overrideSortOrderToUseOffset,
-        onCheckedChange = viewModel::toggleOverrideSortOrderToUseOffset
-    )
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Default sort order uses file name (ASC)\n" +
+                    "Override Sort Order to Use Offset: $overrideSortOrderToUseOffset"
+        )
+        Checkbox(
+            checked = overrideSortOrderToUseOffset,
+            onCheckedChange = viewModel::toggleOverrideSortOrderToUseOffset
+        )
+    }
 }
 
 @Composable
 private fun MergeFilesOverrideConfigSegment(
     overrideMergeFiles: Boolean,
-    viewModel: MainViewModel
+    viewModel: MainViewModel,
 ) {
-    Text(
-        text = "Default Behavior:\nApplies logic to each individual CBZ file.\n" +
-                "Merge Files Override, mergers all files into one file.\n" +
-                "Then applies additional configuration to that one file.\n"+
-                "Note: When using this option the first file selected will be used as filename,\n" +
-                "Unless an override file name is provide.\n"+
-                "Merge Files Override: $overrideMergeFiles"
-    )
-    Checkbox(
-        checked = overrideMergeFiles,
-        onCheckedChange = viewModel::toggleMergeFilesOverride
-    )
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Default Behavior:\nApplies logic to each individual CBZ file.\n" +
+                    "Merge Files Override, mergers all files into one file.\n" +
+                    "Then applies additional configuration to that one file.\n"+
+                    "Note: When using this option the first file selected will be used as filename,\n" +
+                    "Unless an override file name is provide.\n"+
+                    "Merge Files Override: $overrideMergeFiles"
+        )
+        Checkbox(
+            checked = overrideMergeFiles,
+            onCheckedChange = viewModel::toggleMergeFilesOverride
+        )
+    }
 }
 
 @Composable
@@ -227,32 +256,39 @@ private fun MaxNumberOfPagesConfigSegment(
     maxNumberOfPages: Int,
     viewModel: MainViewModel,
     focusManager: FocusManager,
-    isCurrentlyConverting: Boolean
+    isCurrentlyConverting: Boolean,
 ) {
-    Text(text = "Max Number of Pages per PDF: $maxNumberOfPages")
-    Spacer(modifier = Modifier.height(16.dp))
-    var tempMaxNumberOfPages by remember { mutableStateOf(maxNumberOfPages.toString()) }
-    TextField(
-        value = tempMaxNumberOfPages,
-        onValueChange = { tempMaxNumberOfPages = it },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-        keyboardActions = KeyboardActions(onDone = {
-            viewModel.updateMaxNumberOfPagesSizeFromUserInput(tempMaxNumberOfPages)
-            focusManager.clearFocus()
-        }),
-        label = {
-            if (!maxNumberOfPages.toString().contentEquals(tempMaxNumberOfPages)) {
-                Text(
-                    text = "Value not saved, click Done (✓) on keyboard",
-                    color = Color.Red
-                )
-            } else {
-                Text("Update Max Number of Pages per PDF")
-            }
-        },
-        enabled = !isCurrentlyConverting,
-        singleLine = true
-    )
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Max Number of Pages per PDF: $maxNumberOfPages")
+        Spacer(modifier = Modifier.height(16.dp))
+        var tempMaxNumberOfPages by remember { mutableStateOf(maxNumberOfPages.toString()) }
+        TextField(
+            value = tempMaxNumberOfPages,
+            onValueChange = { tempMaxNumberOfPages = it },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            keyboardActions = KeyboardActions(onDone = {
+                viewModel.updateMaxNumberOfPagesSizeFromUserInput(tempMaxNumberOfPages)
+                focusManager.clearFocus()
+            }),
+            label = {
+                if (!maxNumberOfPages.toString().contentEquals(tempMaxNumberOfPages)) {
+                    Text(
+                        text = "Value not saved, click Done (✓) on keyboard",
+                        color = Color.Red
+                    )
+                } else {
+                    Text("Update Max Number of Pages per PDF")
+                }
+            },
+            enabled = !isCurrentlyConverting,
+            singleLine = true
+        )
+    }
 }
 
 @Composable
@@ -260,46 +296,53 @@ private fun BatchSizeConfigSegment(
     batchSize: Int,
     viewModel: MainViewModel,
     focusManager: FocusManager,
-    isCurrentlyConverting: Boolean
+    isCurrentlyConverting: Boolean,
 ) {
-    Text(
-        text = "Memory Batch Size: $batchSize\n" +
-                "Controls memory usage by processing images in memory batches.\n" +
-                "Lower values use less memory but may be slower.\n" +
-                "Higher values are faster but use more memory.\n" +
-                "Note: Does not affect end result, only memory usage.\n" +
-                "Note: If you are having issues with memory running out when converting, try lowering this value. Suggestion: 20-50 pages under the number where it failed to convert. (e.g. failed when converting page \"203\" change value to \"150\")"
-    )
-    Spacer(modifier = Modifier.height(16.dp))
-    var tempBatchSize by remember { mutableStateOf(batchSize.toString()) }
-    TextField(
-        value = tempBatchSize,
-        onValueChange = { tempBatchSize = it },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-        keyboardActions = KeyboardActions(onDone = {
-            viewModel.updateBatchSizeFromUserInput(tempBatchSize)
-            focusManager.clearFocus()
-        }),
-        label = {
-            if (!batchSize.toString().contentEquals(tempBatchSize)) {
-                Text(
-                    text = "Value not saved, click Done (✓) on keyboard",
-                    color = Color.Red
-                )
-            } else {
-                Text("Update Memory Batch Size")
-            }
-        },
-        enabled = !isCurrentlyConverting,
-        singleLine = true
-    )
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Memory Batch Size: $batchSize\n" +
+                    "Controls memory usage by processing images in memory batches.\n" +
+                    "Lower values use less memory but may be slower.\n" +
+                    "Higher values are faster but use more memory.\n" +
+                    "Note: Does not affect end result, only memory usage.\n" +
+                    "Note: If you are having issues with memory running out when converting, try lowering this value. Suggestion: 20-50 pages under the number where it failed to convert. (e.g. failed when converting page \"203\" change value to \"150\")"
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        var tempBatchSize by remember { mutableStateOf(batchSize.toString()) }
+        TextField(
+            value = tempBatchSize,
+            onValueChange = { tempBatchSize = it },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            keyboardActions = KeyboardActions(onDone = {
+                viewModel.updateBatchSizeFromUserInput(tempBatchSize)
+                focusManager.clearFocus()
+            }),
+            label = {
+                if (!batchSize.toString().contentEquals(tempBatchSize)) {
+                    Text(
+                        text = "Value not saved, click Done (✓) on keyboard",
+                        color = Color.Red
+                    )
+                } else {
+                    Text("Update Memory Batch Size")
+                }
+            },
+            enabled = !isCurrentlyConverting,
+            singleLine = true
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun ConfigurationPagePreview() {
+fun ConfigurationsSegmentPreview() {
     CbzConverterTheme {
-        ConfigurationPage(
+        ConfigurationsSegment(
             maxNumberOfPages = 100,
             batchSize = 300,
             viewModel = MainViewModel(contextHelper = ContextHelper(ComponentActivity())),
@@ -310,10 +353,7 @@ fun ConfigurationPagePreview() {
             selectedFilesUri = listOf(),
             overrideOutputDirectoryUri = null,
             activity = ComponentActivity(),
-            directoryPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? ->
-                uri?.let {
-                }
-            }
+            directoryPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? -> }
         )
     }
 }


### PR DESCRIPTION
## Summary
- Replace bottom sheet entry point with a mode selection home screen
- Provide back-arrow top bars and remember the chosen mode across app restarts
- Stub out a Mihon converter page and route Normal mode to the existing converter UI
- Clean up formatting and indentation across MainActivity and UI layers

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e2a6f3c48330bdc02a074ce9f5fc