### PR TITLE
Handle activity context safely in UI components

### DIFF
--- a/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.joshiminh.cbzconverter.backend.ContextHelper
 import com.joshiminh.cbzconverter.backend.MainViewModel
@@ -52,7 +53,6 @@ class MainActivity : ComponentActivity() {
                 when (selectedMode) {
                     "normal" ->
                         NormalModeScreen(
-                            activity = this,
                             onBack = {
                                 selectedMode = null
                                 prefs.edit().remove("selected_mode").apply()
@@ -107,8 +107,9 @@ fun ModeSelectionScreen(onNormal: () -> Unit, onMihon: () -> Unit) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NormalModeScreen(activity: ComponentActivity, onBack: () -> Unit) {
-    val viewModel = remember { MainViewModel(ContextHelper(activity)) }
+fun NormalModeScreen(onBack: () -> Unit) {
+    val activity = LocalContext.current as ComponentActivity
+    val viewModel = remember(activity) { MainViewModel(ContextHelper(activity)) }
     val isCurrentlyConverting by viewModel.isCurrentlyConverting.collectAsState()
     val currentTaskStatus by viewModel.currentTaskStatus.collectAsState()
     val currentSubTaskStatus by viewModel.currentSubTaskStatus.collectAsState()
@@ -146,7 +147,6 @@ fun NormalModeScreen(activity: ComponentActivity, onBack: () -> Unit) {
             CbzConverterPage(
                 selectedFileName,
                 viewModel,
-                activity,
                 filePickerLauncher,
                 isCurrentlyConverting,
                 selectedFilesUri,

--- a/app/src/main/java/com/joshiminh/cbzconverter/ui/normal/CbzConverterPage.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/ui/normal/CbzConverterPage.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,7 +34,6 @@ import com.joshiminh.cbzconverter.theme.CbzConverterTheme
 fun CbzConverterPage(
     selectedFileName: String,
     viewModel: MainViewModel,
-    activity: ComponentActivity,
     filePickerLauncher: ManagedActivityResultLauncher<Array<String>, List<Uri>>,
     isCurrentlyConverting: Boolean,
     selectedFilesUri: List<Uri>,
@@ -59,7 +59,6 @@ fun CbzConverterPage(
         FileConversionSegment(
             selectedFileName,
             viewModel,
-            activity,
             filePickerLauncher,
             isCurrentlyConverting,
             selectedFilesUri,
@@ -79,7 +78,6 @@ fun CbzConverterPage(
             overrideFileName,
             selectedFilesUri,
             overrideOutputDirectoryUri,
-            activity,
             directoryPickerLauncher,
         )
 
@@ -141,7 +139,6 @@ private fun TasksStatusSegment(
 private fun FileConversionSegment(
     selectedFileName: String,
     viewModel: MainViewModel,
-    activity: ComponentActivity,
     filePickerLauncher: ManagedActivityResultLauncher<Array<String>, List<Uri>>,
     isCurrentlyConverting: Boolean,
     selectedFilesUri: List<Uri>,
@@ -167,7 +164,8 @@ private fun FileConversionSegment(
 
         Button(
             onClick = {
-                viewModel.checkPermissionAndSelectFileAction(activity, filePickerLauncher)
+                val activity = LocalContext.current as? ComponentActivity
+                activity?.let { viewModel.checkPermissionAndSelectFileAction(it, filePickerLauncher) }
             },
             enabled = !isCurrentlyConverting,
         ) {
@@ -193,7 +191,6 @@ fun CbzConverterPagePreview() {
         CbzConverterPage(
             selectedFileName = "Sample File Name",
             viewModel = MainViewModel(contextHelper = ContextHelper(ComponentActivity())),
-            activity = ComponentActivity(),
             filePickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uri: List<Uri> ->
                 uri.let {
                 }
@@ -220,7 +217,6 @@ fun FileConversionSegmentPreview() {
         FileConversionSegment(
             selectedFileName = "Sample File Name",
             viewModel = MainViewModel(contextHelper = ContextHelper(ComponentActivity())),
-            activity = ComponentActivity(),
             filePickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uri: List<Uri> ->
                 uri.let {
                 }

--- a/app/src/main/java/com/joshiminh/cbzconverter/ui/normal/Configurations.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/ui/normal/Configurations.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -48,7 +49,6 @@ fun ConfigurationsSegment(
     overrideFileName: String,
     selectedFilesUri: List<Uri>,
     overrideOutputDirectoryUri: Uri?,
-    activity: ComponentActivity,
     directoryPickerLauncher: ManagedActivityResultLauncher<Uri?, Uri?>,
 ) {
     val scrollState = rememberScrollState()
@@ -118,7 +118,6 @@ fun ConfigurationsSegment(
         OutputDirectoryOverrideConfigSegment(
             overrideOutputDirectoryUri,
             viewModel,
-            activity,
             directoryPickerLauncher,
             isCurrentlyConverting,
         )
@@ -129,7 +128,6 @@ fun ConfigurationsSegment(
 private fun OutputDirectoryOverrideConfigSegment(
     overrideOutputDirectoryUri: Uri?,
     viewModel: MainViewModel,
-    activity: ComponentActivity,
     directoryPickerLauncher: ManagedActivityResultLauncher<Uri?, Uri?>,
     isCurrentlyConverting: Boolean,
 ) {
@@ -151,7 +149,8 @@ private fun OutputDirectoryOverrideConfigSegment(
         Button(
             onClick = {
                 // todo look into why you cannot choose any directory, even though you have full access to storage
-                viewModel.checkPermissionAndSelectDirectoryAction(activity, directoryPickerLauncher)
+                val activity = LocalContext.current as? ComponentActivity
+                activity?.let { viewModel.checkPermissionAndSelectDirectoryAction(it, directoryPickerLauncher) }
             },
             enabled = !isCurrentlyConverting
         ) {
@@ -352,7 +351,6 @@ fun ConfigurationsSegmentPreview() {
             overrideFileName = "test",
             selectedFilesUri = listOf(),
             overrideOutputDirectoryUri = null,
-            activity = ComponentActivity(),
             directoryPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? -> }
         )
     }
@@ -416,7 +414,6 @@ fun OutputDirectoryOverrideConfigSegmentPreview() {
         OutputDirectoryOverrideConfigSegment(
             overrideOutputDirectoryUri = null,
             viewModel = MainViewModel(contextHelper = ContextHelper(ComponentActivity())),
-            activity = ComponentActivity(),
             directoryPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? ->
                 uri?.let {
                 }


### PR DESCRIPTION
## Summary
- Avoid passing explicit Activity references by sourcing the context via `LocalContext`
- Update file and directory selection handlers to guard against missing Activity instances
- Simplify Normal Mode screen setup and remove unused Activity parameters

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaa63652083308a0cc2e870eb78ef