### PR TITLE
feat: add PDF compression option

### DIFF
--- a/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
@@ -142,6 +142,7 @@ private fun MainApp(
             val overrideMergeFiles by viewModel.overrideMergeFiles.collectAsState()
             val overrideFileName by viewModel.overrideFileName.collectAsState()
             val overrideOutputDirectoryUri by viewModel.overrideOutputDirectoryUri.collectAsState()
+            val compressOutputPdf by viewModel.compressOutputPdf.collectAsState()
 
             // Pickers for files and directory (the latter is now required)
             val filePickerLauncher =
@@ -188,6 +189,7 @@ private fun MainApp(
                         overrideMergeFiles = overrideMergeFiles,
                         overrideFileName = overrideFileName,
                         overrideOutputDirectoryUri = overrideOutputDirectoryUri,
+                        compressOutputPdf = compressOutputPdf,
                         directoryPickerLauncher = directoryPickerLauncher
                     )
                 }

--- a/app/src/main/java/com/joshiminh/cbzconverter/backend/MainViewModel.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/backend/MainViewModel.kt
@@ -72,6 +72,9 @@ class MainViewModel(private val contextHelper: ContextHelper) : ViewModel() {
     private val _overrideOutputDirectoryUri = MutableStateFlow<Uri?>(null)
     val overrideOutputDirectoryUri = _overrideOutputDirectoryUri.asStateFlow()
 
+    private val _compressOutputPdf = MutableStateFlow(false)
+    val compressOutputPdf = _compressOutputPdf.asStateFlow()
+
     // --------------------------- Mutators ----------------------------
 
     fun toggleOverrideSortOrderToUseOffset(newValue: Boolean) {
@@ -80,6 +83,10 @@ class MainViewModel(private val contextHelper: ContextHelper) : ViewModel() {
 
     fun toggleMergeFilesOverride(newValue: Boolean) {
         _overrideMergeFiles.update { newValue }
+    }
+
+    fun toggleCompressOutputPdf(newValue: Boolean) {
+        _compressOutputPdf.update { newValue }
     }
 
     fun updateMaxNumberOfPagesSizeFromUserInput(maxNumberOfPages: String) {
@@ -171,6 +178,7 @@ class MainViewModel(private val contextHelper: ContextHelper) : ViewModel() {
                     outputFileNames = pdfFileNames,
                     overrideSortOrderToUseOffset = _overrideSortOrderToUseOffset.value,
                     overrideMergeFiles = _overrideMergeFiles.value,
+                    compressOutputPdf = _compressOutputPdf.value,
                     outputDirectory = outputFolder
                 )
 

--- a/app/src/main/java/com/joshiminh/cbzconverter/ui/NormalMode.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/ui/NormalMode.kt
@@ -1,5 +1,5 @@
 /*TODO:
-- [ ] Add PDF Compression
+- [x] Add PDF Compression
  */
 @file:Suppress("SameParameterValue")
 
@@ -73,6 +73,7 @@ fun NormalMode(
     overrideMergeFiles: Boolean,
     overrideFileName: String,
     overrideOutputDirectoryUri: Uri?,
+    compressOutputPdf: Boolean,
     directoryPickerLauncher: ManagedActivityResultLauncher<Uri?, Uri?>
 ) {
     val focusManager: FocusManager = LocalFocusManager.current
@@ -214,6 +215,16 @@ fun NormalMode(
                             checked = overrideMergeFiles,
                             enabled = !isCurrentlyConverting
                         ) { viewModel.toggleMergeFilesOverride(it) }
+
+                        Spacer12Divider()
+
+                        // PDF compression — instant toggle
+                        ConfigSwitchItem(
+                            title = "Compress Output PDF",
+                            infoText = "Use compression to reduce PDF file size (slower processing).",
+                            checked = compressOutputPdf,
+                            enabled = !isCurrentlyConverting
+                        ) { viewModel.toggleCompressOutputPdf(it) }
 
                         Spacer12Divider()
 


### PR DESCRIPTION
## Summary
- add `compressOutputPdf` state to view model and UI wiring
- allow backend to use iText compression when enabled
- expose new "Compress Output PDF" switch in normal mode settings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2464c2208330971774938156d009