### PR TITLE
Improve Mihon mode UI and add chapter autonaming toggle

### DIFF
--- a/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
@@ -119,6 +119,7 @@ private fun MainApp(
             val overrideFileName by viewModel.overrideFileName.collectAsState()
             val overrideOutputDirectoryUri by viewModel.overrideOutputDirectoryUri.collectAsState()
             val compressOutputPdf by viewModel.compressOutputPdf.collectAsState()
+            val autoNameWithChapters by viewModel.autoNameWithChapters.collectAsState()
             val mihonDirectoryUri by viewModel.mihonDirectoryUri.collectAsState()
             val mihonMangaEntries by viewModel.mihonMangaEntries.collectAsState()
 
@@ -166,6 +167,7 @@ private fun MainApp(
                         overrideFileName = overrideFileName,
                         overrideOutputDirectoryUri = overrideOutputDirectoryUri,
                         compressOutputPdf = compressOutputPdf,
+                        autoNameWithChapters = autoNameWithChapters,
                         directoryPickerLauncher = directoryPickerLauncher,
                         mihonDirectoryUri = mihonDirectoryUri,
                         onSelectMihonDirectory = {

--- a/app/src/main/java/com/joshiminh/cbzconverter/backend/MainViewModel.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/backend/MainViewModel.kt
@@ -80,6 +80,9 @@ class MainViewModel(private val contextHelper: ContextHelper) : ViewModel() {
     private val _compressOutputPdf = MutableStateFlow(false)
     val compressOutputPdf = _compressOutputPdf.asStateFlow()
 
+    private val _autoNameWithChapters = MutableStateFlow(false)
+    val autoNameWithChapters = _autoNameWithChapters.asStateFlow()
+
     private val _mihonDirectoryUri = MutableStateFlow<Uri?>(null)
     val mihonDirectoryUri = _mihonDirectoryUri.asStateFlow()
 
@@ -105,6 +108,10 @@ class MainViewModel(private val contextHelper: ContextHelper) : ViewModel() {
 
     fun toggleCompressOutputPdf(newValue: Boolean) {
         _compressOutputPdf.update { newValue }
+    }
+
+    fun toggleAutoNameWithChapters(newValue: Boolean) {
+        _autoNameWithChapters.update { newValue }
     }
 
     fun updateMihonDirectoryUri(newUri: Uri) {


### PR DESCRIPTION
## Summary
- streamline Mihon mode layout with tighter padding
- split file selection into separate cards and use cards for manga options
- add optional "Autonaming with Chapters" config toggle

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7aa6e91483309fae554f09e09173