### PR TITLE
Improve Mihon auto loading and memory handling

### DIFF
--- a/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
@@ -122,6 +122,8 @@ private fun MainApp(
             val autoNameWithChapters by viewModel.autoNameWithChapters.collectAsState()
             val mihonDirectoryUri by viewModel.mihonDirectoryUri.collectAsState()
             val mihonMangaEntries by viewModel.mihonMangaEntries.collectAsState()
+            val isLoadingMihonManga by viewModel.isLoadingMihonManga.collectAsState()
+            val mihonLoadProgress by viewModel.mihonLoadProgress.collectAsState()
 
             val directoryPickerLauncher =
                 rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? ->
@@ -170,6 +172,8 @@ private fun MainApp(
                         autoNameWithChapters = autoNameWithChapters,
                         directoryPickerLauncher = directoryPickerLauncher,
                         mihonDirectoryUri = mihonDirectoryUri,
+                        isLoadingMihonManga = isLoadingMihonManga,
+                        mihonLoadProgress = mihonLoadProgress,
                         onSelectMihonDirectory = {
                             viewModel.checkPermissionAndSelectDirectoryAction(activity, mihonDirectoryPickerLauncher)
                         }

--- a/app/src/main/java/com/joshiminh/cbzconverter/backend/ConversionFunctions.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/backend/ConversionFunctions.kt
@@ -482,7 +482,7 @@ private fun addEntriesToZip(
                 val currentFileUniqueName = "${formattedIndex}_${fileName}_${zipEntry.name}"
 
                 zipOutputStream.putNextEntry(ZipEntry(currentFileUniqueName))
-                zipFile.getInputStream(zipEntry).copyTo(zipOutputStream)
+                zipFile.getInputStream(zipEntry).use { it.copyTo(zipOutputStream) }
                 zipOutputStream.closeEntry()
                 zipOutputStream.flush()
             } catch (e: Exception) {

--- a/app/src/main/java/com/joshiminh/cbzconverter/ui/MihonMode.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/ui/MihonMode.kt
@@ -42,7 +42,9 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,10 +83,21 @@ fun MihonMode(
     autoNameWithChapters: Boolean,
     directoryPickerLauncher: ManagedActivityResultLauncher<Uri?, Uri?>,
     mihonDirectoryUri: Uri?,
+    isLoadingMihonManga: Boolean,
+    mihonLoadProgress: Float,
     onSelectMihonDirectory: () -> Unit
 ) {
     val focusManager: FocusManager = LocalFocusManager.current
     val canMerge = viewModel.areSelectedFilesFromSameParent()
+
+    // Automatically refresh the Mihon manga list whenever a directory has been
+    // previously selected (e.g. on app reopen). This avoids requiring the user to
+    // reselect the directory each time the screen is opened.
+    LaunchedEffect(mihonDirectoryUri) {
+        if (mihonDirectoryUri != null) {
+            viewModel.refreshMihonManga()
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -124,6 +137,13 @@ fun MihonMode(
                 Text("Manga Selection", fontWeight = FontWeight.SemiBold)
                 Spacer(Modifier.height(8.dp))
                 if (mihonDirectoryUri != null) {
+                    if (isLoadingMihonManga) {
+                        LinearProgressIndicator(
+                            progress = mihonLoadProgress,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Spacer(Modifier.height(8.dp))
+                    }
                     var searchQuery by rememberSaveable { mutableStateOf("") }
                     OutlinedTextField(
                         value = searchQuery,


### PR DESCRIPTION
## Summary
- lower default memory batch size to 200 to avoid crashes when converting large merged image sets
- auto-name Mihon outputs with detected chapter numbers and ranges
- close CBZ entry streams during merges to prevent errors
- show a progress bar while loading the Mihon manga list to keep the UI responsive

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47c00b8a8833099c920035a8a8b85