### PR TITLE
Improve placeholder filename detection

### DIFF
--- a/app/src/main/java/com/joshiminh/cbzconverter/backend/ContextHelper.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/backend/ContextHelper.kt
@@ -84,15 +84,24 @@ class ContextHelper(private val context: Context) {
         return s
     }
 
-    /** True if the candidate looks like a real filename, not a generic placeholder. */
+    /**
+     * True if the candidate looks like a real filename, not a generic placeholder.
+     * The base name is derived by removing the extension and any trailing numeric
+     * suffixes such as "-1" or "(1)" before comparison.
+     */
     private fun isMeaningful(name: String): Boolean {
         if (name.isBlank()) return false
-        val lower = name.lowercase()
-        // Common generic names exposed by SAF providers
-        if (lower == "document" || lower == "file" || lower == "download" || lower == "content") {
-            return false
-        }
-        // Sometimes providers return "document (1).pdf" etc. Accept those (they’re unique enough)
+
+        // Normalize by stripping extension and trailing numeric suffixes
+        var base = name.lowercase().substringBeforeLast('.')
+        base = base
+            .replace(Regex("\\s*\\(\\d+\\)$"), "") // "document(1)" -> "document"
+            .replace(Regex("[-_\\s]*\\d+$"), "")        // "document-1" -> "document"
+            .trim()
+
+        val placeholders = listOf("document", "file", "download", "content")
+        if (placeholders.any { base.startsWith(it) }) return false
+
         return true
     }
 

--- a/app/src/test/java/com/joshiminh/cbzconverter/backend/ContextHelperTest.kt
+++ b/app/src/test/java/com/joshiminh/cbzconverter/backend/ContextHelperTest.kt
@@ -1,0 +1,45 @@
+package com.joshiminh.cbzconverter.backend
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.MatrixCursor
+import android.net.Uri
+import android.provider.OpenableColumns
+import com.anggrayudi.storage.file.DocumentFileCompat
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.isNull
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+
+class ContextHelperTest {
+    @Test
+    fun getFileName_falls_back_when_display_name_is_placeholder() {
+        val context = mock(Context::class.java)
+        val resolver = mock(ContentResolver::class.java)
+        Mockito.`when`(context.contentResolver).thenReturn(resolver)
+
+        val cursor = MatrixCursor(arrayOf(OpenableColumns.DISPLAY_NAME))
+        cursor.addRow(arrayOf("document.pdf"))
+        Mockito.`when`(
+            resolver.query(
+                any(Uri::class.java),
+                any(Array<String>::class.java),
+                isNull(),
+                isNull(),
+                isNull()
+            )
+        ).thenReturn(cursor)
+
+        val uri = Uri.parse("content://provider/tree/primary:Download/MyComic.pdf")
+
+        Mockito.mockStatic(DocumentFileCompat::class.java).use { dfMock ->
+            dfMock.`when`<DocumentFileCompat?> { DocumentFileCompat.fromUri(context, uri) }.thenReturn(null)
+
+            val helper = ContextHelper(context)
+            val result = helper.getFileName(uri)
+            assertEquals("MyComic.pdf", result)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refine filename placeholder detection by stripping extensions and numeric suffixes
- add unit test covering fallback when URI reports generic "document.pdf"

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68be39946fe48330b2696e0a4cbe1e8a