### PR TITLE
Handle placeholder filenames by using parent folder names

### DIFF
--- a/app/src/test/java/com/joshiminh/cbzconverter/backend/MainViewModelTest.kt
+++ b/app/src/test/java/com/joshiminh/cbzconverter/backend/MainViewModelTest.kt
@@ -1,0 +1,85 @@
+package com.joshiminh.cbzconverter.backend
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import java.io.File
+import java.nio.file.Files
+
+class MainViewModelTest {
+
+    @Test
+    fun getPdfFileNames_falls_back_to_parent_when_placeholder() {
+        val helper = mock(ContextHelper::class.java)
+        val ctx = mock(Context::class.java)
+        Mockito.`when`(helper.getContext()).thenReturn(ctx)
+
+        val uri1 = Uri.parse("content://provider/ParentOne/file.cbz")
+        val uri2 = Uri.parse("content://provider/ParentTwo/file.cbz")
+
+        Mockito.`when`(helper.getFileName(uri1)).thenReturn("Unknown")
+        Mockito.`when`(helper.getFileName(uri2)).thenReturn("Unknown")
+
+        val viewModel = MainViewModel(helper)
+
+        Mockito.mockStatic(DocumentFile::class.java).use { dfMock ->
+            dfMock.`when`<DocumentFile?> {
+                DocumentFile.fromSingleUri(any(Context::class.java), any(Uri::class.java))
+            }.thenReturn(null)
+
+            val method = viewModel.javaClass.getDeclaredMethod(
+                "getPdfFileNames",
+                List::class.java,
+                Boolean::class.javaPrimitiveType
+            )
+            method.isAccessible = true
+            val names = method.invoke(viewModel, listOf(uri1, uri2), false) as List<String>
+            assertEquals(listOf("ParentOne.pdf", "ParentTwo.pdf"), names)
+        }
+    }
+
+    @Test
+    fun resolveFileNameConflicts_handles_duplicate_parent_fallbacks() {
+        val helper = mock(ContextHelper::class.java)
+        val ctx = mock(Context::class.java)
+        Mockito.`when`(helper.getContext()).thenReturn(ctx)
+
+        val uri1 = Uri.parse("content://provider/Parent/file1.cbz")
+        val uri2 = Uri.parse("content://provider/Parent/file2.cbz")
+
+        Mockito.`when`(helper.getFileName(uri1)).thenReturn("Unknown")
+        Mockito.`when`(helper.getFileName(uri2)).thenReturn("Unknown")
+
+        val viewModel = MainViewModel(helper)
+
+        Mockito.mockStatic(DocumentFile::class.java).use { dfMock ->
+            dfMock.`when`<DocumentFile?> {
+                DocumentFile.fromSingleUri(any(Context::class.java), any(Uri::class.java))
+            }.thenReturn(null)
+
+            val getNames = viewModel.javaClass.getDeclaredMethod(
+                "getPdfFileNames",
+                List::class.java,
+                Boolean::class.javaPrimitiveType
+            )
+            getNames.isAccessible = true
+            val baseNames = getNames.invoke(viewModel, listOf(uri1, uri2), false) as List<String>
+
+            val resolve = viewModel.javaClass.getDeclaredMethod(
+                "resolveFileNameConflicts",
+                List::class.java,
+                File::class.java
+            )
+            resolve.isAccessible = true
+            val outputDir = Files.createTempDirectory("mvmt").toFile()
+            val resolved = resolve.invoke(viewModel, baseNames, outputDir) as List<String>
+            assertEquals(listOf("Parent.pdf", "Parent 1.pdf"), resolved)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Derive output names from parent folders when SAF returns placeholder filenames
- Ensure placeholder detection via `isPlaceholderName`
- Add tests covering parent-folder fallback and conflict resolution

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bedc0f4f70833081b9f89a03453080