### PR TITLE
Optimize Mihon selection performance and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
 <h1 align="center">CBZConverter</h1>
 
-An App Created To Convert `.CBZ` Files Into `.PDF` Files, Directly On Your Android Device.
+CBZConverter lets you convert `.cbz` manga archives into `.pdf` files directly on your Android device.
 
-- Single Or Batch Conversion: Convert A Single Or Multiple `.CBZ` Files At Once
-- Merge CBZ Files Into One Convert
-- Sorting Options: Sort Files Based On Their Offset Within The `.CBZ` File Or By File Name (Default In Ascending Order)
-- Page Limits: Set A Maximum Number Of Pages For The PDF And Automatically Split The PDF Into Multiple Parts
-- Two Modes: Normal Mode Picks Files From Storage, Mihon Mode Searches Your Mihon Library
-- Auto Naming: Output PDFs Use Manga Titles And Detected Chapter Numbers, Adding Numeric Suffixes For Duplicates
-- Configurable Options: Memory Batch Size, Output Directory, Sort Order Override, Merge Behavior, PDF Compression, And Chapter-Based Naming
-- Send To Kindle: Quickly Open Amazon's Send-To-Kindle Page
-... And More
+## Features
+- Convert one or many CBZ files in a single run.
+- Merge multiple archives into a single PDF when the files belong to the same series.
+- Keep large series organized with sorting, custom output names, and optional chapter-aware auto naming.
+- Control memory usage with configurable batch sizes and page limits that automatically split huge books into parts.
+- Browse files manually or load your Mihon downloads for quick checkbox selection.
+- Optional PDF compression plus the ability to pick a custom output directory.
+
+## Support the creator
+If you enjoy the app and want to help future development, consider supporting the creator:
+
+- [Patreon](https://patreon.com/u16604577?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink)
+- [Ko-fi](https://ko-fi.com/joshiminh)
+
+## Build
+```
+./gradlew assembleRelease
+```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
+                "proguard-rules.pro"
             )
         }
     }
@@ -45,49 +45,43 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1" // consider moving to libs.versions.toml
+        kotlinCompilerExtensionVersion = "1.5.1"
     }
 
     packaging {
         resources {
             excludes += setOf(
                 "/META-INF/{AL2.0,LGPL2.1}",
-                "META-INF/*",
+                "META-INF/*"
             )
         }
     }
 }
 
 dependencies {
-    // Core
+    implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
 
-    // Compose (BOM first)
     implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.material.icons.extended)
+    implementation(libs.androidx.material3)
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
-    implementation(libs.androidx.material.icons.extended)
 
-    // App libs
-    implementation(libs.storage)
     implementation(libs.itext.core)
+    implementation(libs.storage)
 
-    // Test
+    debugImplementation(libs.androidx.ui.test.manifest)
+    debugImplementation(libs.androidx.ui.tooling)
+
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.ui.test.junit4)
+
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.inline)
-
-    // Android Test
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-
-    // Debug tools
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/MainActivity.kt
@@ -275,7 +275,12 @@ private fun MihonMode(
                             mihonLoadProgress = mihonLoadProgress,
                             mihonManga = mihonManga,
                             selectedFilesUri = selectedFilesUri,
-                            onToggleSelection = { viewModel.toggleFileSelection(it) }
+                            onToggleSelection = { uri, isSelected ->
+                                viewModel.setFileSelection(uri, isSelected)
+                            },
+                            onToggleGroup = { uris, isSelected ->
+                                viewModel.setFilesSelection(uris, isSelected)
+                            }
                         )
 
                         SelectionMode.Manual -> ManualSelectionCard(
@@ -326,8 +331,9 @@ private fun MihonMode(
                 ) {
                     SelectedFilesList(
                         selectedFiles = selectedFilesUri,
+                        resolveInfo = viewModel::getSelectedFileInfo,
                         onMove = { from, to -> viewModel.moveSelectedFile(from, to) },
-                        onRemove = { uri -> viewModel.toggleFileSelection(uri) }
+                        onRemove = { uri -> viewModel.setFileSelection(uri, false) }
                     )
                 }
             }

--- a/app/src/main/java/com/joshiminh/cbzconverter/components/MangaToggleList.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/components/MangaToggleList.kt
@@ -36,7 +36,8 @@ import com.joshiminh.cbzconverter.backend.MihonMangaEntry
 fun MangaToggleList(
     manga: List<MihonMangaEntry>,
     selectedUris: List<Uri>,
-    onToggle: (Uri) -> Unit
+    onToggleSingle: (Uri, Boolean) -> Unit,
+    onToggleGroup: (List<Uri>, Boolean) -> Unit
 ) {
     if (manga.isEmpty()) {
         Text("No CBZ files found")
@@ -72,11 +73,7 @@ fun MangaToggleList(
                         Checkbox(
                             checked = allSelected,
                             onCheckedChange = { checked ->
-                                entry.files.forEach { file ->
-                                    val contains = selectedUriSet.contains(file.uri)
-                                    if (checked && !contains) onToggle(file.uri)
-                                    else if (!checked && contains) onToggle(file.uri)
-                                }
+                                onToggleGroup(entry.files.map { it.uri }, checked)
                             }
                         )
                         Text(
@@ -105,7 +102,9 @@ fun MangaToggleList(
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     Checkbox(
                                         checked = selectedUriSet.contains(file.uri),
-                                        onCheckedChange = { onToggle(file.uri) }
+                                        onCheckedChange = { checked ->
+                                            onToggleSingle(file.uri, checked)
+                                        }
                                     )
                                     Text(
                                         file.name,

--- a/app/src/main/java/com/joshiminh/cbzconverter/components/SelectionCards.kt
+++ b/app/src/main/java/com/joshiminh/cbzconverter/components/SelectionCards.kt
@@ -63,7 +63,8 @@ fun MihonSelectionCard(
     mihonLoadProgress: Float,
     mihonManga: List<MihonMangaEntry>,
     selectedFilesUri: List<Uri>,
-    onToggleSelection: (Uri) -> Unit
+    onToggleSelection: (Uri, Boolean) -> Unit,
+    onToggleGroup: (List<Uri>, Boolean) -> Unit
 ) {
     Column(Modifier.fillMaxWidth()) {
         Text(
@@ -121,7 +122,8 @@ fun MihonSelectionCard(
             MangaToggleList(
                 manga = filtered,
                 selectedUris = selectedFilesUri,
-                onToggle = onToggleSelection
+                onToggleSingle = onToggleSelection,
+                onToggleGroup = onToggleGroup
             )
         } else {
             Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
## Summary
- cache CBZ metadata, add bulk selection helpers, and reduce redundant main-thread work during Mihon selections
- update Compose selection UI to use the new APIs so large checkbox operations run once and reuse cached labels
- tidy the Gradle build script and refresh the README with donation links, a centered heading, and cleaner formatting

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf713813308330b402da96eaf362bc